### PR TITLE
Support for ARC and error reporting

### DIFF
--- a/TestApp/TestAppAppDelegate.m
+++ b/TestApp/TestAppAppDelegate.m
@@ -29,6 +29,20 @@
 {
     // Insert code here to initialize your application
     mathConnection = [[XPCConnection alloc] initWithServiceName:@"com.mustacheware.TestService"];
+	mathConnection.errorHandler = ^(xpc_object_t object, NSString *description, XPCConnection *inConnection) {
+		if (object == XPC_ERROR_CONNECTION_INTERRUPTED) {
+			// test by adding abort() or assert() to TestService's main.m file
+			NSLog(@"XPC_ERROR_CONNECTION_INTERRUPTED: %@", description);
+	 	} else if (object == XPC_ERROR_CONNECTION_INVALID) {
+			// test by using invalid name in initWithServiceName: above
+			NSLog(@"XPC_ERROR_CONNECTION_INVALID: %@", description);
+		} else if (object == XPC_ERROR_TERMINATION_IMMINENT) {
+			// Not really an error, but more like a message that the app/service is terminating AFAIK, not sure how to test it or if it even needs to be handled, but it's here for the sake of completness...
+			NSLog(@"XPC_ERROR_TERMINATION_IMMINENT: %@", description);
+		} else {
+			NSLog(@"ERROR: %@", description);
+		}
+	};	
     mathConnection.eventHandler = ^(NSDictionary *message, XPCConnection *inConnection){
 		NSNumber *result = [message objectForKey:@"result"];
 		NSData *data = [message objectForKey:@"data"];

--- a/XPCKit.xcodeproj/project.pbxproj
+++ b/XPCKit.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		1EEDD01F13DD485400D5AEC3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0420;
 				ORGANIZATIONNAME = Mustacheware;
 			};
 			buildConfigurationList = 1EEDD02213DD485400D5AEC3 /* Build configuration list for PBXProject "XPCKit" */;

--- a/XPCKit/NSArray+XPCParse.m
+++ b/XPCKit/NSArray+XPCParse.m
@@ -31,7 +31,11 @@
 		}
 		return true;
 	});
+#if __has_feature(objc_arc)
+	return [array copy];
+#else
 	return [[array copy] autorelease];
+#endif
 }
 
 -(xpc_object_t)newXPCObject{

--- a/XPCKit/NSDictionary+XPCParse.m
+++ b/XPCKit/NSDictionary+XPCParse.m
@@ -32,7 +32,11 @@
         }
         return true;
     });
+#if __has_feature(objc_arc)
+	return [dict copy];
+#else
     return [[dict copy] autorelease];
+#endif
 }
 
 -(xpc_object_t)newXPCObject{

--- a/XPCKit/NSFileHandle+XPCParse.m
+++ b/XPCKit/NSFileHandle+XPCParse.m
@@ -23,7 +23,10 @@
 
 +(NSFileHandle *)fileHandleWithXPCObject:(xpc_object_t)xpc{
 	int fd = xpc_fd_dup(xpc);
-	NSFileHandle *handle = [[[NSFileHandle alloc] initWithFileDescriptor:fd closeOnDealloc:YES] autorelease];
+	NSFileHandle *handle = [[NSFileHandle alloc] initWithFileDescriptor:fd closeOnDealloc:YES];
+#if !__has_feature(objc_arc)
+	[handle autorelease];
+#endif
 	return handle;
 }
 

--- a/XPCKit/XPCConnection.h
+++ b/XPCKit/XPCConnection.h
@@ -30,6 +30,7 @@
 - (id)initWithConnection: (xpc_connection_t)connection;
 
 @property (nonatomic, copy)   XPCEventHandler eventHandler;
+@property (nonatomic, copy)   XPCErrorHandler errorHandler;
 
 @property (nonatomic, readonly)   xpc_connection_t connection;
 @property (nonatomic, assign)     dispatch_queue_t dispatchQueue;

--- a/XPCKit/XPCConnection.m
+++ b/XPCKit/XPCConnection.m
@@ -37,7 +37,9 @@
 
 -(id)initWithConnection:(xpc_connection_t)connection{
 	if(!connection){
+#if !__has_feature(objc_arc)
 		[self release];
+#endif
 		return nil;
 	}
 	
@@ -60,8 +62,9 @@
 		xpc_release(_connection);
 		_connection = NULL;
 	}
-	
+#if !__has_feature(objc_arc)	
 	[super dealloc];
+#endif
 }
 
 -(void)setDispatchQueue:(dispatch_queue_t)dispatchQueue{

--- a/XPCKit/XPCService.h
+++ b/XPCKit/XPCService.h
@@ -24,7 +24,11 @@
 @interface XPCService : NSObject
 
 @property (nonatomic, copy) XPCConnectionHandler connectionHandler;
+#if __has_feature(objc_arc)
+@property (nonatomic, strong, readonly) NSArray *connections;
+#else
 @property (nonatomic, readonly) NSArray *connections;
+#endif
 
 +(void)runServiceWithConnectionHandler:(XPCConnectionHandler)connectionHandler;
 -(id)initWithConnectionHandler:(XPCConnectionHandler)connectionHandler;

--- a/XPCKit/XPCService.m
+++ b/XPCKit/XPCService.m
@@ -23,7 +23,9 @@ static void XPCServiceConnectionHandler(xpc_connection_t handler);
 static void XPCServiceConnectionHandler(xpc_connection_t handler){
 	XPCConnection *connection = [[XPCConnection alloc] initWithConnection:handler];
 	[[NSNotificationCenter defaultCenter] postNotificationName:XPCConnectionReceivedNotification object:connection];
+#if !__has_feature(objc_arc)
 	[connection release];
+#endif
 }
 
 @implementation XPCService
@@ -71,7 +73,11 @@ static void XPCServiceConnectionHandler(xpc_connection_t handler){
 	
 	[XPCService runService];
 	
+#if __has_feature(objc_arc)
+	(void)service;	// get rid of unused variable warning under ARC...
+#else
 	[service release];
+#endif
 }
 
 @end

--- a/XPCKit/XPCTypes.h
+++ b/XPCKit/XPCTypes.h
@@ -23,6 +23,7 @@
 
 @class XPCConnection;
 typedef void (^XPCEventHandler)(NSDictionary *, XPCConnection *);
+typedef void (^XPCErrorHandler)(xpc_object_t, NSString *, XPCConnection *);
 typedef void (^XPCConnectionHandler)(XPCConnection *);
 
 #pragma mark Notifications

--- a/XPCKit/XPCUUID.m
+++ b/XPCKit/XPCUUID.m
@@ -31,7 +31,10 @@
 
 +(XPCUUID *)uuid{
 	CFUUIDRef uuidRef = CFUUIDCreate(NULL);
-	XPCUUID *uuid = [[[self alloc] initWithUUIDRef:uuidRef] autorelease];
+	XPCUUID *uuid = [[self alloc] initWithUUIDRef:uuidRef];
+#if !__has_feature(objc_arc)
+	[uuid autorelease];
+#endif
 	CFRelease(uuidRef);
 	return uuid;
 }
@@ -60,7 +63,10 @@
 #undef CopyByte
 	
 	CFUUIDRef uuidRef = CFUUIDCreateFromUUIDBytes(NULL, uuidBytes);
-	XPCUUID *uuid = [[[self alloc] initWithUUIDRef:uuidRef] autorelease];
+	XPCUUID *uuid = [[self alloc] initWithUUIDRef:uuidRef];
+#if !__has_feature(objc_arc)	
+	[uuid autorelease];
+#endif
 
 	CFRelease(uuidRef);
 	
@@ -97,7 +103,12 @@
 }
 
 -(NSString *)string{
-	return [((NSString *)CFUUIDCreateString(NULL, self.uuidRef)) autorelease];
+	CFStringRef result = CFUUIDCreateString(NULL, self.uuidRef);
+#if __has_feature(objc_arc)
+	return (__bridge NSString *)result;
+#else
+	return [((NSString *)result) autorelease];
+#endif
 }
 
 -(NSString *)description{
@@ -128,7 +139,9 @@
 		_uuidRef = nil;
 	}
 
+#if !__has_feature(objc_arc)
 	[super dealloc];
+#endif
 }
 
 @end


### PR DESCRIPTION
Hey! I've adopted XPCKit to my app and it's been really smooth sailing so far (much smoother then using XPC API directly, not to mention clearer code etc). Gladly I've code across your lib as I was about to write my own (not nearly as sophisticated, just to cover my needs). Anyway, I added two things which I use in my app:
- ARC support: works for both non-arc and arc builds, although it makes the code a bit ugly due to #if/#else statements. If you later port it fully to ARC, you can remove all the conditionals (probably makes sense as XPC itself is Lion only, so probably folks will also adopt ARC).
- Error reporting support: there's additional block handler in `XPCConnection` that's invoked when an error is detected. Also updated TestApp to demonstrate how it can be used.

If you think this would be useful for other users, feel free to merge into main repo, otherwise just close the pull request :)

Thanks for the lib! Tom
